### PR TITLE
Layers 2.1 (backwards compatible)

### DIFF
--- a/res/layout/contact_tile_frequent.xml
+++ b/res/layout/contact_tile_frequent.xml
@@ -38,7 +38,7 @@
             android:id="@+id/contact_tile_name"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textColor="@android:color/black"
+            android:textColor="@color/frequent_contact_text_color"
             android:textSize="@dimen/contact_browser_list_item_text_size"
             android:singleLine="true"
             android:fadingEdge="horizontal"

--- a/res/layout/contact_tile_starred.xml
+++ b/res/layout/contact_tile_starred.xml
@@ -43,7 +43,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="7dp"
-            android:textColor="#202020"
+            android:textColor="@color/contact_tile_text_color"
             android:textSize="@dimen/contact_browser_list_item_text_size"
             android:singleLine="true"
             android:fadingEdge="horizontal"

--- a/res/layout/contact_tile_starred_quick_contact.xml
+++ b/res/layout/contact_tile_starred_quick_contact.xml
@@ -47,7 +47,7 @@
                 android:id="@+id/contact_tile_name"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@android:color/white"
+                android:textColor="@color/starred_quick_contact_name_text_color"
                 android:textSize="16sp"
                 android:singleLine="true"
                 android:fadingEdge="horizontal"

--- a/res/values/colors.xml
+++ b/res/values/colors.xml
@@ -68,39 +68,39 @@
         These colors are also used by MaterialColorMapUtils to generate primary activity colors.
     -->
     <array name="letter_tile_colors">
-        <item>#DB4437</item>
-        <item>#E91E63</item>
-        <item>#9C27B0</item>
-        <item>#673AB7</item>
-        <item>#3F51B5</item>
-        <item>#4285F4</item>
-        <item>#039BE5</item>
-        <item>#0097A7</item>
-        <item>#009688</item>
-        <item>#0F9D58</item>
-        <item>#689F38</item>
-        <item>#EF6C00</item>
-        <item>#FF5722</item>
-        <item>#757575</item>
+        <item>@color/letter_tile_red_color</item>
+        <item>@color/letter_tile_pink_color</item>
+        <item>@color/letter_tile_purple_color</item>
+        <item>@color/letter_tile_deep_purple_color</item>
+        <item>@color/letter_tile_indigo_color</item>
+        <item>@color/letter_tile_blue_color</item>
+        <item>@color/letter_tile_light_blue_color</item>
+        <item>@color/letter_tile_cyan_color</item>
+        <item>@color/letter_tile_teal_color</item>
+        <item>@color/letter_tile_green_color</item>
+        <item>@color/letter_tile_light_green_color</item>
+        <item>@color/letter_tile_orange_color</item>
+        <item>@color/letter_tile_deep_orange_color</item>
+        <item>@color/letter_tile_grey_color</item>
     </array>
 
     <!-- Darker versions of letter_tile_colors, two shades darker. These colors are used
         for settings secondary activity colors. -->
     <array name="letter_tile_colors_dark">
-        <item>#C53929</item>
-        <item>#C2185B</item>
-        <item>#7B1FA2</item>
-        <item>#512DA8</item>
-        <item>#303F9F</item>
-        <item>#3367D6</item>
-        <item>#0277BD</item>
-        <item>#006064</item>
-        <item>#00796B</item>
-        <item>#0B8043</item>
-        <item>#33691E</item>
-        <item>#E65100</item>
-        <item>#E64A19</item>
-        <item>#424242</item>
+        <item>@color/letter_tile_red_color_dark</item>
+        <item>@color/letter_tile_pink_color_dark</item>
+        <item>@color/letter_tile_purple_color_dark</item>
+        <item>@color/letter_tile_deep_purple_color_dark</item>
+        <item>@color/letter_tile_indigo_color_dark</item>
+        <item>@color/letter_tile_blue_color_dark</item>
+        <item>@color/letter_tile_light_blue_color_dark</item>
+        <item>@color/letter_tile_cyan_color_dark</item>
+        <item>@color/letter_tile_teal_color_dark</item>
+        <item>@color/letter_tile_green_color_dark</item>
+        <item>@color/letter_tile_light_green_color_dark</item>
+        <item>@color/letter_tile_orange_color_dark</item>
+        <item>@color/letter_tile_deep_orange_color_dark</item>
+        <item>@color/letter_tile_grey_color_dark</item>
     </array>
 
     <!-- The default color used for tinting photos when no color can be extracted via Palette,

--- a/res/values/custom_colors.xml
+++ b/res/values/custom_colors.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+     Copyright (C) 2015 The CyanogenMod Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <color name="text_highlight_color">#3B77E7</color>
+    <color name="contact_tile_text_color">#ff202020</color>
+    <color name="starred_quick_contact_name_text_color">@color/exposed_primary_text_dark</color>
+    <color name="frequent_contact_text_color">@color/exposed_primary_text_light</color>
+
+<!-- Background colors for LetterTileDrawables definitions. -->
+    <color name="letter_tile_red_color">#DB4437</color>
+    <color name="letter_tile_pink_color">#E91E63</color>
+    <color name="letter_tile_purple_color">#9C27B0</color>
+    <color name="letter_tile_deep_purple_color">#673AB7</color>
+    <color name="letter_tile_indigo_color">#3F51B5</color>
+    <color name="letter_tile_blue_color">#4285F4</color>
+    <color name="letter_tile_light_blue_color">#039BE5</color>
+    <color name="letter_tile_cyan_color">#0097A7</color>
+    <color name="letter_tile_teal_color">#009688</color>
+    <color name="letter_tile_green_color">#0F9D58</color>
+    <color name="letter_tile_light_green_color">#689F38</color>
+    <color name="letter_tile_orange_color">#EF6C00</color>
+    <color name="letter_tile_deep_orange_color">#FF5722</color>
+    <color name="letter_tile_grey_color">#757575</color>
+    <color name="letter_tile_red_color_dark">#C53929</color>
+    <color name="letter_tile_pink_color_dark">#C2185B</color>
+    <color name="letter_tile_purple_color_dark">#7B1FA2</color>
+    <color name="letter_tile_deep_purple_color_dark">#512DA8</color>
+    <color name="letter_tile_indigo_color_dark">#303F9F</color>
+    <color name="letter_tile_blue_color_dark">#3367D6</color>
+    <color name="letter_tile_light_blue_color_dark">#0277BD</color>
+    <color name="letter_tile_cyan_color_dark">#006064</color>
+    <color name="letter_tile_teal_color_dark">#00796B</color>
+    <color name="letter_tile_green_color_dark">#0B8043</color>
+    <color name="letter_tile_light_green_color_dark">#33691E</color>
+    <color name="letter_tile_orange_color_dark">#E65100</color>
+    <color name="letter_tile_deep_orange_color_dark">#E64A19</color>
+    <color name="letter_tile_grey_color_dark">#424242</color>
+</resources> 

--- a/res/values/layers_colors.xml
+++ b/res/values/layers_colors.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2007 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+
+<resources>
+    <!-- exposed colors for theming -->
+    <color name="exposed_primary_text_light">@android:color/black</color>
+    <color name="exposed_primary_text_dark">@android:color/white</color>
+</resources> 

--- a/src/com/android/contacts/common/format/TextHighlighter.java
+++ b/src/com/android/contacts/common/format/TextHighlighter.java
@@ -16,14 +16,12 @@
 
 package com.android.contacts.common.format;
 
-import android.graphics.Typeface;
 import android.text.SpannableString;
 import android.text.style.CharacterStyle;
 import android.text.style.ForegroundColorSpan;
 import android.text.style.StyleSpan;
 import android.widget.TextView;
 
-import com.google.common.base.Preconditions;
 
 /**
  * Highlights the text in a text field.
@@ -33,12 +31,20 @@ public class TextHighlighter {
     private final static boolean DEBUG = false;
 
     private int mTextStyle;
+    private int mHighlightColor;
 
     private CharacterStyle mTextStyleSpan;
+    private CharacterStyle mTextColorStyleSpan;
 
     public TextHighlighter(int textStyle) {
+        this(textStyle, -1);
+    }
+
+    public TextHighlighter(int textStyle, int highlightColor) {
         mTextStyle = textStyle;
+        mHighlightColor = highlightColor;
         mTextStyleSpan = getStyleSpan();
+        mTextColorStyleSpan = getColorStyleSpan();
     }
 
     /**
@@ -56,6 +62,13 @@ public class TextHighlighter {
         return new StyleSpan(mTextStyle);
     }
 
+    private CharacterStyle getColorStyleSpan() {
+        if (mHighlightColor != -1) {
+            return new ForegroundColorSpan(mHighlightColor);
+        }
+        return null;
+    }
+
     /**
      * Applies highlight span to the text.
      * @param text Text sequence to be highlighted.
@@ -65,6 +78,9 @@ public class TextHighlighter {
     public void applyMaskingHighlight(SpannableString text, int start, int end) {
         /** Sets text color of the masked locations to be highlighted. */
         text.setSpan(getStyleSpan(), start, end, 0);
+        if (mTextColorStyleSpan != null) {
+            text.setSpan(getColorStyleSpan(), start, end, 0);
+        }
     }
 
     /**
@@ -90,6 +106,9 @@ public class TextHighlighter {
         if (index != -1) {
             final SpannableString result = new SpannableString(text);
             result.setSpan(mTextStyleSpan, index, index + trimmedPrefix.length(), 0 /* flags */);
+            if (mTextColorStyleSpan != null) {
+                result.setSpan(mTextColorStyleSpan, index, index + trimmedPrefix.length(), 0 /* flags */);
+            }
             return result;
         } else {
             return text;

--- a/src/com/android/contacts/common/list/ContactListItemView.java
+++ b/src/com/android/contacts/common/list/ContactListItemView.java
@@ -225,7 +225,9 @@ public class ContactListItemView extends ViewGroup
     public ContactListItemView(Context context) {
         super(context);
 
-        mTextHighlighter = new TextHighlighter(Typeface.BOLD);
+        mTextHighlighter = new TextHighlighter(Typeface.BOLD,
+                context.getResources().getColor(R.color.text_highlight_color));
+
         mNameHighlightSequence = new ArrayList<HighlightSequence>();
         mNumberHighlightSequence = new ArrayList<HighlightSequence>();
     }
@@ -278,7 +280,8 @@ public class ContactListItemView extends ViewGroup
                 a.getDimensionPixelOffset(
                         R.styleable.ContactListItemView_list_item_padding_bottom, 0));
 
-        mTextHighlighter = new TextHighlighter(Typeface.BOLD);
+        mTextHighlighter = new TextHighlighter(Typeface.BOLD,
+            context.getResources().getColor(R.color.text_highlight_color));
 
         a.recycle();
 


### PR DESCRIPTION
This is a rework of the initial layers type 2 commit

Changes naming conventions to coexist with AOSP/CMTE naming

Original commit:
Layers : Exposing hard coded resources for type 2 overlay access [4/6]
Author: bgill55
https://github.com/BitSyko/platform_packages_apps_ContactsCommon/commit/efcc85c54f46170f91714061bfe86aea75a1adbb

Backwards compatibility based on
[WIP] Resources: Layers 2 backwards-compatibility (Settings)
Author: Andrew Dodd
https://gerrit.omnirom.org/#/c/12695/

CM commits:
Exposed hard coded text colors for starred/group tiles.
Author: 93Akkord
https://github.com/CyanogenMod/android_packages_apps_ContactsCommon/commit/898ee9c8298e4a9a66d942ca33d068840fb2dc92

Expose colors from array
Author: djdarkknight96
https://github.com/CyanogenMod/android_packages_apps_ContactsCommon/commit/0c375a8a833f122eb12da9a172b15216ebda4b1e

ContactsCommon: Add optional text highlight color
Author: cretin45
https://github.com/CyanogenMod/android_packages_apps_ContactsCommon/commit/ffb6b0d7d1fe9e569bf570bc238eef99ad224a7a
